### PR TITLE
Use Gatsby's Img component to display inline images from Drupal.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-osiolabs-drupal-blog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "index.js",
   "scripts": {
@@ -15,6 +15,7 @@
     "semantic-ui-react": "^0.88.1"
   },
   "dependencies": {
+    "@emotion/core": "^10.0.27",
     "gatsby-theme-osiolabs-drupal": "git+https://github.com/OsioLabs/gatsby-theme-osiolabs-drupal.git"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "gatsby-theme-osiolabs-drupal": "git+https://github.com/OsioLabs/gatsby-theme-osiolabs-drupal.git"
+    "gatsby-theme-osiolabs-drupal": "git+https://github.com/OsioLabs/gatsby-theme-osiolabs-drupal.git",
+    "react-html-parser": "^2.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "semantic-ui-react": "^0.88.1"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.27",
     "gatsby-theme-osiolabs-drupal": "git+https://github.com/OsioLabs/gatsby-theme-osiolabs-drupal.git",
     "react-html-parser": "^2.0.2"
   },

--- a/src/components/Blog/BlogPostTemplate.jsx
+++ b/src/components/Blog/BlogPostTemplate.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Container, Header, Item } from 'semantic-ui-react';
 import Img from 'gatsby-image';
+import ReactHtmlParser from 'react-html-parser';
 import BlogPostTeaser from './BlogPostTeaser';
 
 const BlogPostTemplate = props => {
@@ -16,6 +17,28 @@ const BlogPostTemplate = props => {
     previousPost,
     nextPost,
   } = props;
+
+  let postBody = <div dangerouslySetInnerHTML={{ __html: body }} />
+  if (bodyImages) {
+    postBody = new ReactHtmlParser(body, {
+      transform: function transform(node) {
+        if (
+          node.type === 'tag' &&
+          node.name === 'article' &&
+          node.attribs['data-media-source'] === 'image'
+        ) {
+          const imageData = bodyImages.find(
+            el =>
+              el.drupal_internal__fid ===
+              parseInt(node.attribs['data-media-source-value'])
+          )
+          if (imageData) {
+            return <Img fluid={imageData.localFile.childImageSharp.fluid} />
+          }
+        }
+      },
+    })
+  }
 
   return (
     <>
@@ -32,7 +55,7 @@ const BlogPostTemplate = props => {
           By {author} on {created}
           {timeToComplete && <> // {timeToComplete} min to read</>}
         </div>
-        <div dangerouslySetInnerHTML={{ __html: body }} />
+        {postBody}
       </Container>
       <Item.Group className="blog-navigation">
         {previousPost && (
@@ -60,6 +83,7 @@ BlogPostTemplate.propTypes = {
   created: PropTypes.string.isRequired,
   author: PropTypes.string.isRequired,
   images: PropTypes.array,
+  bodyImages: PropTypes.array,
   timeToComplete: PropTypes.number,
   previousPost: PropTypes.oneOfType([
     PropTypes.bool,
@@ -81,6 +105,7 @@ BlogPostTemplate.defaultProps = {
   previousPost: false,
   nextPost: false,
   images: [],
+  bodyImages: null,
 };
 
 export default BlogPostTemplate;

--- a/src/components/Blog/BlogPostTemplate.jsx
+++ b/src/components/Blog/BlogPostTemplate.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import PropTypes from "prop-types";
-import { Container, Header, Item } from "semantic-ui-react";
+import PropTypes from 'prop-types';
+import { Container, Header, Item } from 'semantic-ui-react';
 import Img from 'gatsby-image';
-import BlogPostTeaser from "./BlogPostTeaser";
+import BlogPostTeaser from './BlogPostTeaser';
 
 const BlogPostTemplate = props => {
   const {
@@ -10,6 +10,7 @@ const BlogPostTemplate = props => {
     created,
     author,
     body,
+    bodyImages,
     images,
     timeToComplete,
     previousPost,
@@ -21,15 +22,15 @@ const BlogPostTemplate = props => {
       <Container as="article" className="blog-post">
         {images[0] && (
           <Img
-            fluid={images[0].relationships.imageFile.localFile.childImageSharp.fluid}
+            fluid={
+              images[0].relationships.imageFile.localFile.childImageSharp.fluid
+            }
           />
         )}
         <Header as="h2">{title}</Header>
         <div className="meta">
           By {author} on {created}
-          {timeToComplete && (
-            <> // {timeToComplete} min to read</>
-          )}
+          {timeToComplete && <> // {timeToComplete} min to read</>}
         </div>
         <div dangerouslySetInnerHTML={{ __html: body }} />
       </Container>

--- a/src/templates/blog-page.js
+++ b/src/templates/blog-page.js
@@ -22,9 +22,12 @@ const BlogPostTemplateWithData = props => {
   // Note: This doesn't work with Drupal out of the box and requires some code
   // on the Drupal side to add the `data-media-source-value` attribute used
   // here.
-  const regexp = /data-media-source-value="(\d+)"/gm;
-  const matches = [...props.data.post.body.processed.matchAll(regexp)];
-  const imageIds = matches.map(match => parseInt(match[1]));
+  const re = /data-media-source-value="(\d+)"/gm;
+  let imageIds = [];
+  let match;
+  while ((match = re.exec(props.data.post.body.processed)) != null) {
+    imageIds.push(parseInt(match[1]));
+  }
 
   let bodyImages = null;
   if (imageIds.length && props.data.allImages.edges.length) {

--- a/src/templates/blog-page.test.js
+++ b/src/templates/blog-page.test.js
@@ -6,21 +6,21 @@ import BlogPostTemplateWithData from './blog-page';
 const exampleData = {
   post: {
     body: {
-      processed: "<p>Blog post body</p>\n"
+      processed: '<p>Blog post body</p>\n',
     },
-    drupal_id: "4675f421-ab2a-41db-9946-0dad9343b06b",
+    drupal_id: '4675f421-ab2a-41db-9946-0dad9343b06b',
     drupal_internal__nid: 274,
-    title: "Current blog post title",
-    created: "Sep. 9th, 2019",
+    title: 'Current blog post title',
+    created: 'Sep. 9th, 2019',
     path: {
-      alias: "/blog/tue-09242019-1631/abico-ibidem-oppeto-uxor"
+      alias: '/blog/tue-09242019-1631/abico-ibidem-oppeto-uxor',
     },
     summary: {
-      processed: "<p>Blog post summary.</p>\n"
+      processed: '<p>Blog post summary.</p>\n',
     },
     relationships: {
       uid: {
-        display_name: "Current blog author"
+        display_name: 'Current blog author',
       },
       image: [
         {
@@ -29,16 +29,19 @@ const exampleData = {
               localFile: {
                 childImageSharp: {
                   fluid: {
-                    base64: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAALCAYAAAB/Ca1DAAAACXBIWXMAAAsSAAALEgHS3X78AAABrklEQVQoz52RvW4TQRSF9xlBQlQICqCi4g1okChQOoQoKHgBGkpSBIlIkaLgOItSRMZiFdu73v/dmVlbjr/cmVnHq3RQfLpnZvacuXM30FcTzOkvzHlI9+OY7vDI158nqLKi1RrVtiilHO097dmvA2vYoboOZQztDmu+M3njUGvxWHyg7ElosDMoOSjynLIsnd511fbdePbdadFpmrIUrHahtkMXKN2YRYx+e4B5/wEtoY3sN02DElrB6kZMtV3LWVEp3n1refO1ZZ5pjPahgTOs15jfl/DwGTx+gYmuSbOMJJZLqopUarJMKWvFXC4u8oxoaXj0CR58hDAyrLvWXSiBkrxaoSdTtk9fcfPyNSYvSCRwMZ+jpfuZ1NlsRic6jhPKIiOvDM+/3PDk85bJQrMyfaAfdD8ruV0lSzcj+8S6rp22teq1e3rjZxnnioU81/9h1T/ZDbqnMx7R2g5e+x9h6512P8TrTubWmYFfCKpas0f1+HU5qOXgu/Le2TAjCKMt/8NhCMcjxdHFhu+jDeeXivAagvFf+FcuIjibwunVhtF0y9mfLePphrHs3wJGBzn7XXcIlQAAAABJRU5ErkJggg==",
+                    base64:
+                      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAALCAYAAAB/Ca1DAAAACXBIWXMAAAsSAAALEgHS3X78AAABrklEQVQoz52RvW4TQRSF9xlBQlQICqCi4g1okChQOoQoKHgBGkpSBIlIkaLgOItSRMZiFdu73v/dmVlbjr/cmVnHq3RQfLpnZvacuXM30FcTzOkvzHlI9+OY7vDI158nqLKi1RrVtiilHO097dmvA2vYoboOZQztDmu+M3njUGvxWHyg7ElosDMoOSjynLIsnd511fbdePbdadFpmrIUrHahtkMXKN2YRYx+e4B5/wEtoY3sN02DElrB6kZMtV3LWVEp3n1refO1ZZ5pjPahgTOs15jfl/DwGTx+gYmuSbOMJJZLqopUarJMKWvFXC4u8oxoaXj0CR58hDAyrLvWXSiBkrxaoSdTtk9fcfPyNSYvSCRwMZ+jpfuZ1NlsRic6jhPKIiOvDM+/3PDk85bJQrMyfaAfdD8ruV0lSzcj+8S6rp22teq1e3rjZxnnioU81/9h1T/ZDbqnMx7R2g5e+x9h6512P8TrTubWmYFfCKpas0f1+HU5qOXgu/Le2TAjCKMt/8NhCMcjxdHFhu+jDeeXivAagvFf+FcuIjibwunVhtF0y9mfLePphrHs3wJGBzn7XXcIlQAAAABJRU5ErkJggg==',
                     aspectRatio: 1.7777777777777777,
-                    src: "/static/1e96bf19ddb341300e3a0fbb3db66c92/91f24/diagram-etl-pipeline.png",
-                    srcSet: "/static/1e96bf19ddb341300e3a0fbb3db66c92/a79b5/diagram-etl-pipeline.png 320w,\n/static/1e96bf19ddb341300e3a0fbb3db66c92/cff51/diagram-etl-pipeline.png 640w,\n/static/1e96bf19ddb341300e3a0fbb3db66c92/91f24/diagram-etl-pipeline.png 1280w,\n/static/1e96bf19ddb341300e3a0fbb3db66c92/ec873/diagram-etl-pipeline.png 1920w",
-                    sizes: "(max-width: 1280px) 100vw, 1280px"
-                  }
-                }
-              }
-            }
-          }
+                    src:
+                      '/static/1e96bf19ddb341300e3a0fbb3db66c92/91f24/diagram-etl-pipeline.png',
+                    srcSet:
+                      '/static/1e96bf19ddb341300e3a0fbb3db66c92/a79b5/diagram-etl-pipeline.png 320w,\n/static/1e96bf19ddb341300e3a0fbb3db66c92/cff51/diagram-etl-pipeline.png 640w,\n/static/1e96bf19ddb341300e3a0fbb3db66c92/91f24/diagram-etl-pipeline.png 1280w,\n/static/1e96bf19ddb341300e3a0fbb3db66c92/ec873/diagram-etl-pipeline.png 1920w',
+                    sizes: '(max-width: 1280px) 100vw, 1280px',
+                  },
+                },
+              },
+            },
+          },
         },
         {
           relationships: {
@@ -46,54 +49,89 @@ const exampleData = {
               localFile: {
                 childImageSharp: {
                   fluid: {
-                    base64: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAHCAYAAAAIy204AAAACXBIWXMAAAsSAAALEgHS3X78AAAA7klEQVQoz4WQC0+DMBSF9/9/2ZY5txnFiOPRZhQYrowBofR1hBpJNIgnvbk3J71fT7rqug5VVaFtW3DO3VzXDcqydB7scKz9UaO++2+tRiAlFIQQ+O8+ojgCoQTeqweWstmlv2AOOF3SFkYMgwG0+JqNtBBND9kp9K1Ed+9htFlM6oBS9fjIrjitE8T7DKdN4ip8YAi3DNEuRbBhiB8zSKEm0FxSB1Ra4cbvCNYMwQCgxxzkkDvY+MAIDLcpMp9DDElFI5cTaq1RVw3iXYbzSwH2dsUluuH8XIDsc+clXgH6dJk8rcw8cOmD/9Pc7icWbBz+vZwIagAAAABJRU5ErkJggg==",
+                    base64:
+                      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAHCAYAAAAIy204AAAACXBIWXMAAAsSAAALEgHS3X78AAAA7klEQVQoz4WQC0+DMBSF9/9/2ZY5txnFiOPRZhQYrowBofR1hBpJNIgnvbk3J71fT7rqug5VVaFtW3DO3VzXDcqydB7scKz9UaO++2+tRiAlFIQQ+O8+ojgCoQTeqweWstmlv2AOOF3SFkYMgwG0+JqNtBBND9kp9K1Ed+9htFlM6oBS9fjIrjitE8T7DKdN4ip8YAi3DNEuRbBhiB8zSKEm0FxSB1Ra4cbvCNYMwQCgxxzkkDvY+MAIDLcpMp9DDElFI5cTaq1RVw3iXYbzSwH2dsUluuH8XIDsc+clXgH6dJk8rcw8cOmD/9Pc7icWbBz+vZwIagAAAABJRU5ErkJggg==',
                     aspectRatio: 2.827067669172932,
-                    src: "/static/3b4fdb60936e9067d1bec35fab1ee0e1/4020c/recipelist-component-example.png",
-                    srcSet: "/static/3b4fdb60936e9067d1bec35fab1ee0e1/a79b5/recipelist-component-example.png 320w,\n/static/3b4fdb60936e9067d1bec35fab1ee0e1/4020c/recipelist-component-example.png 376w",
-                    sizes: "(max-width: 376px) 100vw, 376px"
-                  }
-                }
-              }
-            }
-          }
+                    src:
+                      '/static/3b4fdb60936e9067d1bec35fab1ee0e1/4020c/recipelist-component-example.png',
+                    srcSet:
+                      '/static/3b4fdb60936e9067d1bec35fab1ee0e1/a79b5/recipelist-component-example.png 320w,\n/static/3b4fdb60936e9067d1bec35fab1ee0e1/4020c/recipelist-component-example.png 376w',
+                    sizes: '(max-width: 376px) 100vw, 376px',
+                  },
+                },
+              },
+            },
+          },
         },
-      ]
-    }
+      ],
+    },
   },
   nextPost: {
-    drupal_id: "8f43eeeb-247c-4f77-8d60-e807a47cdc94",
+    drupal_id: '8f43eeeb-247c-4f77-8d60-e807a47cdc94',
     drupal_internal__nid: 275,
-    title: "Next post title",
-    created: "Sep. 10th, 2019",
+    title: 'Next post title',
+    created: 'Sep. 10th, 2019',
     path: {
-      alias: "/blog/tue-09242019-1631/abluo-diam-dolore-metuo-quia-quibus"
+      alias: '/blog/tue-09242019-1631/abluo-diam-dolore-metuo-quia-quibus',
     },
     summary: {
-      processed: "<p>Next post summary</p>\n"
+      processed: '<p>Next post summary</p>\n',
     },
     relationships: {
       uid: {
-        display_name: "Next post author"
-      }
-    }
+        display_name: 'Next post author',
+      },
+    },
   },
   previousPost: {
-    drupal_id: "74947894-d6e8-4816-b981-5df620d01928",
+    drupal_id: '74947894-d6e8-4816-b981-5df620d01928',
     drupal_internal__nid: 273,
-    title: "Previous post title",
-    created: "Sep. 8th, 2019",
+    title: 'Previous post title',
+    created: 'Sep. 8th, 2019',
     path: {
-      alias: "/blog/tue-09242019-1631/eros"
+      alias: '/blog/tue-09242019-1631/eros',
     },
     summary: {
-      processed: "<p>Previous post summary.</p>\n"
+      processed: '<p>Previous post summary.</p>\n',
     },
     relationships: {
       uid: {
-        display_name: "Previous post author"
-      }
-    }
-  }
+        display_name: 'Previous post author',
+      },
+    },
+  },
+  allImages: {
+    edges: [
+      {
+        node: {
+          relationships: {
+            imageFile: {
+              drupal_internal__fid: 3,
+              localFile: {
+                childImageSharp: {
+                  fluid: {
+                    base64:
+                      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAAsSAAALEgHS3X78AAABn0lEQVQ4y42UC6+CMAyF9///oUYU4xNUwPcDsN6vSQnMwXXJ6LKt3TmnLU7+xvv9lqHBuT/bZ+3h+BRFIbPZTJbLpdrVaiXz+Vwmk4nkeR509AN3At5uN9nv91KWpTyfT52v10ste4y6ruV8PsvlcpHr9TqMkEtZlg3SrqpKkadpqqgt0FdANnjxeDwqqj69QHg6nTTwv5Q5WK/XslgsdG42my8EUN9ut40EvQhtk8uHw0H1vN/vXyiwnD0eDw3qn3UCMqADbaj5CGzNOcmzB3sRokuoLPw1CMfjsQYFgP94E5BySJJE6TBJjl/Q9vBut9NMY/HzWThboGEcx5oU6i8kPJRJnmU61FHOotMVo9FIoihqCjckPFSn06l2Fw9gqUsD0SQF+KaJr51ZGgAWPIie1jlmyb4zKlA2fajDNu12cYOGAAQFHYFAzRr9O3WIfvwgyCLOfbU2NFRD0ECB1wxZiDr9jtb0NE0AWpDBrKMh8EEIVYIiAbSw7YzixB7U+lC79mVQMk10bKh4Q53UqcNf/tgh55Cv6/vFh5x/GR8T3CBN4eAMVAAAAABJRU5ErkJggg==',
+                    tracedSVG:
+                      "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20width='400'%20height='392'/%3e",
+                    srcWebp:
+                      '/static/1a3ca6c912d58556c2adeb686ba056c2/62dd6/drupal-theme-with-react.webp',
+                    srcSetWebp:
+                      '/static/1a3ca6c912d58556c2adeb686ba056c2/61e93/drupal-theme-with-react.webp 200w,\n/static/1a3ca6c912d58556c2adeb686ba056c2/1f5c5/drupal-theme-with-react.webp 400w,\n/static/1a3ca6c912d58556c2adeb686ba056c2/62dd6/drupal-theme-with-react.webp 685w',
+                    originalImg:
+                      '/static/1a3ca6c912d58556c2adeb686ba056c2/68128/drupal-theme-with-react.png',
+                    originalName: 'drupal-theme-with-react.png',
+                    presentationWidth: 685,
+                    presentationHeight: 672,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
 };
 
 /**
@@ -106,9 +144,7 @@ describe('Component: <BlogPostTemplateWithData />', () => {
   it('Correctly prepares data from GraphQL for Blog* components.', () => {
     // Basic snapshot test.
     const { asFragment } = render(
-      <BlogPostTemplateWithData
-        data={exampleData}
-      />
+      <BlogPostTemplateWithData data={exampleData} />
     );
     const firstRender = asFragment();
     expect(firstRender).toMatchSnapshot();


### PR DESCRIPTION
Adds some code to handle dealing with inline images added to the body of a blog post via a `<drupal-media/>` token. It require changes to lehub, specifically, this won't work without code in-place on the Drupal side to add additional data-* attributes to the HTML provided by the Media module.

Note: This won't work without changes to lehub. Though, it should be safe to merge it in since heynode.com and gatsbyguides.com are both pinned to specific tagged releases of this module.